### PR TITLE
Renamed "internal/service" as "internal/business"

### DIFF
--- a/internal/business/user.go
+++ b/internal/business/user.go
@@ -1,5 +1,5 @@
-// Package service orchestrate business logic
-package service
+// Package business orchestrate business logic
+package business
 
 import (
 	"strings"
@@ -8,7 +8,7 @@ import (
 	"github.com/yael-castro/godi/internal/repository"
 )
 
-// UserProvider defines the service that provides information about users
+// UserProvider defines the business that provides information about users
 type UserProvider interface {
 	repository.UserProvider
 }

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -4,9 +4,9 @@ package dependency
 import (
 	"fmt"
 
+	"github.com/yael-castro/godi/internal/business"
 	"github.com/yael-castro/godi/internal/handler"
 	"github.com/yael-castro/godi/internal/repository"
-	"github.com/yael-castro/godi/internal/service"
 )
 
 // Profile defines options of dependency injection
@@ -58,7 +58,7 @@ func handlerDefault(i interface{}) error {
 	}
 
 	h.User = handler.User{
-		UserProvider: service.AccountProvider{
+		UserProvider: business.AccountProvider{
 			UserProvider: repository.NewUProvider(repository.Memory),
 		},
 	}
@@ -74,7 +74,7 @@ func handlerTesting(i interface{}) error {
 	}
 
 	h.User = handler.User{
-		UserProvider: service.AccountProvider{
+		UserProvider: business.AccountProvider{
 			UserProvider: repository.NewUProvider(repository.Mock),
 		},
 	}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,4 +1,4 @@
-// Package handles all http requests made to the app (is the presentation layer)
+// Package handler handles all http requests made to the app (is the presentation layer)
 package handler
 
 import (

--- a/internal/handler/user.go
+++ b/internal/handler/user.go
@@ -3,8 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"github.com/yael-castro/godi/internal/business"
 	"github.com/yael-castro/godi/internal/model"
-	"github.com/yael-castro/godi/internal/service"
 )
 
 // _ implemetation constraint to User struct
@@ -12,7 +12,7 @@ var _ http.Handler = User{}
 
 // User http handler used to handle all requests related to the user
 type User struct {
-	service.UserProvider
+	business.UserProvider
 }
 
 // ServeHTTP decides which http.HandlerFunc use based on the http method

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -14,7 +14,7 @@ type UserProvider interface {
 
 // NewUserProvider abstract factory to UserProvider based on a Type passed as parameter
 //
-// Returns an error if exists an eror with UserProviderImplementation or a invalid Type is passed as parameter
+// Returns an error if exists an error with UserProviderImplementation or a invalid Type is passed as parameter
 func NewUserProvider(t Type) (UserProvider, error) {
 	switch t {
 	case Memory:


### PR DESCRIPTION
The package service was renamed as business to prevent confusions and
make the architecture style more faithful to the most common way of
doing layered architecture

issue initial-architecture

issue initial-architecture